### PR TITLE
Use named window with OVER.

### DIFF
--- a/lib/arel/sql_to_arel/pg_query_visitor.rb
+++ b/lib/arel/sql_to_arel/pg_query_visitor.rb
@@ -948,8 +948,11 @@ module Arel
         start_offset: nil,
         end_offset: nil
       )
-        instance = name.nil? ? Arel::Nodes::Window.new : Arel::Nodes::NamedWindow.new(name)
+        if name.present? && partition_clause.empty? && order_clause.empty?
+          return Arel::Nodes::SqlLiteral.new(name)
+        end
 
+        instance = name.nil? ? Arel::Nodes::Window.new : Arel::Nodes::NamedWindow.new(name)
         instance.tap do |window|
           window.orders = visit order_clause
           window.partitions = visit partition_clause

--- a/spec/arel/sql_to_arel_spec.rb
+++ b/spec/arel/sql_to_arel_spec.rb
@@ -354,6 +354,12 @@ describe 'Arel.sql_to_arel' do
         pg_node: 'PgQuery::WINDOW_DEF'
   visit 'sql', 'WITH "some_name" AS (SELECT \'a\') SELECT "some_name"',
         pg_node: 'PgQuery::WITH_CLAUSE'
+  visit 'select', 'SUM("a") OVER (ORDER BY "a")'
+  visit 'select', 'CAST((AVG("a") OVER running_average) AS FLOAT)',
+        expected_sql: 'SELECT (AVG("a") OVER running_average)::double precision'
+  visit 'select',
+        'SUM("a") OVER w, AVG("a") OVER w FROM "t" ' \
+        'WINDOW "w" AS (PARTITION BY "b" ORDER BY "a" DESC)'
   visit 'select', '11 + (11 + 5)'
   visit 'select', '(12 - 12) - 13'
   visit 'select', '3 + (10 * 10)'


### PR DESCRIPTION
This changes should cover the case when  WINDOW clause has alias and it is referenced in OVER:
```
SELECT sum(salary) OVER w, avg(salary) OVER w
  FROM empsalary
  WINDOW w AS (PARTITION BY depname ORDER BY salary DESC);
```