### PR TITLE
Adds cache mechanism to middleware

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -47,8 +47,10 @@ jobs:
     - name: Rebase
       if: matrix.rebase
       run: |
-        git config --global user.email "ci@github.com"
-        git config --global user.name "GitHub CI"
+        export GIT_AUTHOR_NAME=${CI_COMMIT_AUTHOR_NAME=GithubCI}
+        export GIT_AUTHOR_EMAIL=${CI_COMMIT_AUTHOR_EMAIL=ci@github.comm}
+        export GIT_COMMITTER_NAME=${GIT_AUTHOR_NAME}
+        export GIT_COMMITTER_EMAIL=${GIT_AUTHOR_EMAIL}
         git fetch origin $GITHUB_REF
         git rebase $GITHUB_SHA
 

--- a/lib/arel/middleware/cache_accessor.rb
+++ b/lib/arel/middleware/cache_accessor.rb
@@ -7,15 +7,15 @@ module Arel
         @cache = cache
       end
 
-      def get(original_sql)
-        cache.get cache_key(original_sql)
+      def read(original_sql)
+        cache.read cache_key(original_sql)
       end
 
-      def set(transformed_sql:, transformed_binds:, original_sql:, original_binds:)
+      def write(transformed_sql:, transformed_binds:, original_sql:, original_binds:)
         # To play it safe, the order of binds was changed and therefore we won't reuse the query
         return if transformed_binds != original_binds
 
-        cache.set(cache_key(original_sql), transformed_sql)
+        cache.write(cache_key(original_sql), transformed_sql)
       end
 
       def cache_key_for_sql(sql)

--- a/lib/arel/middleware/cache_accessor.rb
+++ b/lib/arel/middleware/cache_accessor.rb
@@ -12,7 +12,7 @@ module Arel
       end
 
       def set(transformed_sql:, transformed_binds:, original_sql:, original_binds:)
-        # The order of binds was changed and therefore we can't reuse the query
+        # To play it safe, the order of binds was changed and therefore we won't reuse the query
         return if transformed_binds != original_binds
 
         cache.set(cache_key(original_sql), transformed_sql)

--- a/lib/arel/middleware/cache_accessor.rb
+++ b/lib/arel/middleware/cache_accessor.rb
@@ -1,0 +1,35 @@
+module Arel
+  module Middleware
+    class CacheAccessor
+      attr_reader :cache
+
+      def initialize(cache)
+        @cache = cache
+      end
+
+      def get(original_sql)
+        cache.get cache_key(original_sql)
+      end
+
+      def set(transformed_sql:, transformed_binds:, original_sql:, original_binds:)
+        # The order of binds was changed and therefore we can't reuse the query
+        return if transformed_binds != original_binds
+
+        cache.set(cache_key(original_sql), transformed_sql)
+      end
+
+      def cache_key_for_sql(sql)
+        Digest::SHA256.hexdigest(sql)
+      end
+
+      def cache_key(sql)
+        # An important aspect of this cache key method is that it includes hashes of all active
+        # middlewares. If multiple Arel middleware chains that are using the same cache backend,
+        # this cache key mechanism will prevent cache entries leak in the wrong chain.
+
+        active_middleware_cache_key = Arel.middleware.current.map(&:hash).join('&') || 0
+        active_middleware_cache_key + '|' + cache_key_for_sql(sql)
+      end
+    end
+  end
+end

--- a/lib/arel/middleware/chain.rb
+++ b/lib/arel/middleware/chain.rb
@@ -1,43 +1,8 @@
+require_relative './no_op_cache'
+require_relative './cache_accessor'
+
 module Arel
   module Middleware
-    module NoOpCache
-      def self.get(key); end
-
-      def self.set(key, sql); end
-    end
-
-    class CacheAccessor
-      attr_reader :cache
-
-      def initialize(cache)
-        @cache = cache
-      end
-
-      def get(original_sql)
-        cache.get cache_key(original_sql)
-      end
-
-      def set(transformed_sql:, transformed_binds:, original_sql:, original_binds:)
-        # The order of binds was changed and therefore we can't reuse the query
-        return if transformed_binds != original_binds
-
-        cache.set(cache_key(original_sql), transformed_sql)
-      end
-
-      def cache_key_for_sql(sql)
-        Digest::SHA256.hexdigest(sql)
-      end
-
-      def cache_key(sql)
-        # An important aspect of this cache key method is that it includes hashes of all active
-        # middlewares. If multiple Arel middleware chains that are using the same cache backend,
-        # this cache key mechanism will prevent cache entries leak in the wrong chain.
-
-        active_middleware_cache_key = Arel.middleware.current.map(&:hash).join('&') || 0
-        active_middleware_cache_key + '|' + cache_key_for_sql(sql)
-      end
-    end
-
     class Chain
       attr_reader :executing_middleware
       attr_reader :executor

--- a/lib/arel/middleware/chain.rb
+++ b/lib/arel/middleware/chain.rb
@@ -29,6 +29,10 @@ module Arel
       end
 
       def cache_key(sql)
+        # An important aspect of this cache key method is that it includes hashes of all active
+        # middlewares. If multiple Arel middleware chains that are using the same cache backend,
+        # this cache key mechanism will prevent cache entries leak in the wrong chain.
+
         active_middleware_cache_key = Arel.middleware.current.map(&:hash).join('&') || 0
         active_middleware_cache_key + '|' + cache_key_for_sql(sql)
       end

--- a/lib/arel/middleware/chain.rb
+++ b/lib/arel/middleware/chain.rb
@@ -21,9 +21,9 @@ module Arel
         check_middleware_recursion(sql)
 
         updated_context = context.merge(original_sql: sql)
-        enhanced_arel = Arel.enhance(Arel.sql_to_arel(sql, binds: binds))
+        arel = Arel.sql_to_arel(sql, binds: binds)
 
-        result = executor.run(enhanced_arel, updated_context, execute_sql)
+        result = executor.run(arel, updated_context, execute_sql)
 
         result.to_casted_result
       rescue ::PgQuery::ParseError

--- a/lib/arel/middleware/chain.rb
+++ b/lib/arel/middleware/chain.rb
@@ -25,6 +25,7 @@ module Arel
       end
 
       def cache_key(original_sql)
+        # TODO: Add the active middleware to the cache key
         original_sql
       end
     end

--- a/lib/arel/middleware/chain.rb
+++ b/lib/arel/middleware/chain.rb
@@ -13,24 +13,19 @@ module Arel
         @cache = cache
       end
 
-      def get(sql)
-        cache.get(cache_key(sql))
+      def get(original_sql)
+        cache.get cache_key(original_sql)
       end
 
-      def set(transformed_sql:, original_sql:)
-        # no set if bind params changed order
-        # no set if anonymous middleware is given
-        # no set if one or more middlewares explicitly opt-out for caching (this is an idea)
+      def set(transformed_sql:, transformed_binds:, original_sql:, original_binds:)
+        # The order of binds was changed and therefore we can't reuse the query
+        return if transformed_binds != original_binds
 
         cache.set(cache_key(original_sql), transformed_sql)
       end
 
-      def cache_key(sql)
-        # Original SQL
-        # Applied middleware keys (class names or some other id)
-        # Given context? Context can change middleware outcome, should it be part
-        # of the cache key?
-        sql
+      def cache_key(original_sql)
+        original_sql
       end
     end
 

--- a/lib/arel/middleware/chain.rb
+++ b/lib/arel/middleware/chain.rb
@@ -54,46 +54,46 @@ module Arel
         internal_middleware.dup
       end
 
-      def apply(middleware, cache: nil, &block)
+      def apply(middleware, cache: @cache, &block)
         new_middleware = Array.wrap(middleware)
-        continue_chain(new_middleware, internal_context, cache: cache || @cache, &block)
+        continue_chain(new_middleware, internal_context, cache: cache, &block)
       end
       alias only apply
 
       def none(&block)
-        continue_chain([], internal_context, cache: cache || @cache, &block)
+        continue_chain([], internal_context, cache: cache, &block)
       end
 
-      def except(without_middleware, cache: nil, &block)
+      def except(without_middleware, cache: @cache, &block)
         without_middleware = Array.wrap(without_middleware)
         new_middleware = internal_middleware - without_middleware
-        continue_chain(new_middleware, internal_context, cache: cache || @cache, &block)
+        continue_chain(new_middleware, internal_context, cache: cache, &block)
       end
 
-      def insert_before(new_middleware, existing_middleware, cache: nil, &block)
+      def insert_before(new_middleware, existing_middleware, cache: @cache, &block)
         new_middleware = Array.wrap(new_middleware)
         index = internal_middleware.index(existing_middleware)
         updated_middleware = internal_middleware.insert(index, *new_middleware)
-        continue_chain(updated_middleware, internal_context, cache: cache || @cache, &block)
+        continue_chain(updated_middleware, internal_context, cache: cache, &block)
       end
 
-      def prepend(new_middleware, cache: nil, &block)
+      def prepend(new_middleware, cache: @cache, &block)
         new_middleware = Array.wrap(new_middleware)
         updated_middleware = new_middleware + internal_middleware
-        continue_chain(updated_middleware, internal_context, cache: cache || @cache, &block)
+        continue_chain(updated_middleware, internal_context, cache: cache, &block)
       end
 
-      def insert_after(new_middleware, existing_middleware, cache: nil, &block)
+      def insert_after(new_middleware, existing_middleware, cache: @cache, &block)
         new_middleware = Array.wrap(new_middleware)
         index = internal_middleware.index(existing_middleware)
         updated_middleware = internal_middleware.insert(index + 1, *new_middleware)
-        continue_chain(updated_middleware, internal_context, cache: cache || @cache, &block)
+        continue_chain(updated_middleware, internal_context, cache: cache, &block)
       end
 
-      def append(new_middleware, cache: nil, &block)
+      def append(new_middleware, cache: @cache, &block)
         new_middleware = Array.wrap(new_middleware)
         updated_middleware = internal_middleware + new_middleware
-        continue_chain(updated_middleware, internal_context, cache: cache || @cache, &block)
+        continue_chain(updated_middleware, internal_context, cache: cache, &block)
       end
 
       def context(new_context = nil, &block)

--- a/lib/arel/middleware/chain.rb
+++ b/lib/arel/middleware/chain.rb
@@ -1,9 +1,9 @@
 module Arel
   module Middleware
     module NoOpCache
-      def self.get(*_); end
+      def self.get(key); end
 
-      def self.set(**_); end
+      def self.set(key, sql); end
     end
 
     class CacheAccessor
@@ -14,22 +14,23 @@ module Arel
       end
 
       def get(sql)
-        cache.get(sql)
+        cache.get(cache_key(sql))
       end
 
-      def set(**kwargs)
+      def set(transformed_sql:, original_sql:)
         # no set if bind params changed order
         # no set if anonymous middleware is given
         # no set if one or more middlewares explicitly opt-out for caching (this is an idea)
 
-        cache.set(kwargs)
+        cache.set(cache_key(original_sql), transformed_sql)
       end
 
-      def cache_key
+      def cache_key(sql)
         # Original SQL
         # Applied middleware keys (class names or some other id)
         # Given context? Context can change middleware outcome, should it be part
         # of the cache key?
+        sql
       end
     end
 

--- a/lib/arel/middleware/chain.rb
+++ b/lib/arel/middleware/chain.rb
@@ -26,8 +26,8 @@ module Arel
       def execute(sql, binds = [], &execute_sql)
         return execute_sql.call(sql, binds).to_casted_result if internal_middleware.length.zero?
 
-        if (csql = cache.get(sql))
-          return execute_sql.call(csql, binds).to_casted_result
+        if (cached_sql = cache.get(sql))
+          return execute_sql.call(cached_sql, binds).to_casted_result
         end
 
         check_middleware_recursion(sql)
@@ -39,8 +39,9 @@ module Arel
         )
 
         arel = Arel.sql_to_arel(sql, binds: binds)
+        enhanced_arel = Arel.enhance(arel)
 
-        result = executor.run(arel, updated_context, execute_sql)
+        result = executor.run(enhanced_arel, updated_context, execute_sql)
 
         result.to_casted_result
       rescue ::PgQuery::ParseError

--- a/lib/arel/middleware/chain.rb
+++ b/lib/arel/middleware/chain.rb
@@ -28,7 +28,7 @@ module Arel
       def execute(sql, binds = [], &execute_sql)
         return execute_sql.call(sql, binds).to_casted_result if internal_middleware.length.zero?
 
-        if (cached_sql = cache_accessor.get(sql))
+        if (cached_sql = cache_accessor.read(sql))
           return execute_sql.call(cached_sql, binds).to_casted_result
         end
 

--- a/lib/arel/middleware/database_executor.rb
+++ b/lib/arel/middleware/database_executor.rb
@@ -47,7 +47,7 @@ module Arel
       def execute_sql(next_arel)
         sql, binds = next_arel.to_sql_and_binds
 
-        context[:cache_accessor].set(
+        context[:cache_accessor].write(
           transformed_sql: sql,
           transformed_binds: binds,
           original_sql: context[:original_sql],

--- a/lib/arel/middleware/database_executor.rb
+++ b/lib/arel/middleware/database_executor.rb
@@ -11,10 +11,12 @@ module Arel
         @middleware = middleware
       end
 
-      def run(enhanced_arel, context, final_block)
+      def run(arel, context, final_block)
         @index = 0
         @context = context
         @final_block = final_block
+
+        enhanced_arel = Arel.enhance(arel)
 
         result = call(enhanced_arel)
         check_return_type result

--- a/lib/arel/middleware/database_executor.rb
+++ b/lib/arel/middleware/database_executor.rb
@@ -49,7 +49,9 @@ module Arel
 
         context[:cache_accessor].set(
           transformed_sql: sql,
+          transformed_binds: binds,
           original_sql: context[:original_sql],
+          original_binds: context[:original_binds],
         )
 
         sql_result = final_block.call(sql, binds)

--- a/lib/arel/middleware/database_executor.rb
+++ b/lib/arel/middleware/database_executor.rb
@@ -47,8 +47,12 @@ module Arel
       def execute_sql(next_arel)
         sql, binds = next_arel.to_sql_and_binds
 
-        # TODO: don't set cache if the binds != context[:original_binds]
-        context[:cache].set context[:original_sql], sql
+        context[:cache].set(
+          original_sql: context[:original_sql],
+          original_binds: context[:original_binds],
+          transformed_sql: sql,
+          transformed_binds: binds,
+        )
 
         sql_result = final_block.call(sql, binds)
 

--- a/lib/arel/middleware/database_executor.rb
+++ b/lib/arel/middleware/database_executor.rb
@@ -47,7 +47,7 @@ module Arel
       def execute_sql(next_arel)
         sql, binds = next_arel.to_sql_and_binds
 
-        context[:cache].set(
+        context[:cache_accessor].set(
           sql: sql,
           binds: binds,
           context: context,

--- a/lib/arel/middleware/database_executor.rb
+++ b/lib/arel/middleware/database_executor.rb
@@ -48,7 +48,12 @@ module Arel
 
       def execute_sql(next_arel)
         sql, binds = next_arel.to_sql_and_binds
+
+        # TODO: don't set cache if the binds != context[:original_binds]
+        context[:cache].set context[:original_sql], sql
+
         sql_result = final_block.call(sql, binds)
+
         check_return_type sql_result
         sql_result
       end

--- a/lib/arel/middleware/database_executor.rb
+++ b/lib/arel/middleware/database_executor.rb
@@ -48,10 +48,10 @@ module Arel
         sql, binds = next_arel.to_sql_and_binds
 
         context[:cache].set(
-          original_sql: context[:original_sql],
-          original_binds: context[:original_binds],
-          transformed_sql: sql,
-          transformed_binds: binds,
+          sql: sql,
+          binds: binds,
+          context: context,
+          middleware: middleware,
         )
 
         sql_result = final_block.call(sql, binds)

--- a/lib/arel/middleware/database_executor.rb
+++ b/lib/arel/middleware/database_executor.rb
@@ -48,10 +48,8 @@ module Arel
         sql, binds = next_arel.to_sql_and_binds
 
         context[:cache_accessor].set(
-          sql: sql,
-          binds: binds,
-          context: context,
-          middleware: middleware,
+          transformed_sql: sql,
+          original_sql: context[:original_sql],
         )
 
         sql_result = final_block.call(sql, binds)

--- a/lib/arel/middleware/database_executor.rb
+++ b/lib/arel/middleware/database_executor.rb
@@ -16,9 +16,7 @@ module Arel
         @context = context
         @final_block = final_block
 
-        enhanced_arel = Arel.enhance(arel)
-
-        result = call(enhanced_arel)
+        result = call(arel)
         check_return_type result
         result
       ensure

--- a/lib/arel/middleware/no_op_cache.rb
+++ b/lib/arel/middleware/no_op_cache.rb
@@ -1,0 +1,9 @@
+module Arel
+  module Middleware
+    module NoOpCache
+      def self.get(key); end
+      def self.set(key, sql); end
+    end
+  end
+end
+

--- a/lib/arel/middleware/no_op_cache.rb
+++ b/lib/arel/middleware/no_op_cache.rb
@@ -2,8 +2,8 @@ module Arel
   module Middleware
     module NoOpCache
       def self.get(key); end
+
       def self.set(key, sql); end
     end
   end
 end
-

--- a/lib/arel/middleware/no_op_cache.rb
+++ b/lib/arel/middleware/no_op_cache.rb
@@ -1,9 +1,9 @@
 module Arel
   module Middleware
     module NoOpCache
-      def self.get(key); end
+      def self.read(key); end
 
-      def self.set(key, sql); end
+      def self.write(key, sql); end
     end
   end
 end

--- a/spec/arel/transformer/caching_spec.rb
+++ b/spec/arel/transformer/caching_spec.rb
@@ -33,20 +33,20 @@ describe 'Middleware Query Caching' do
     allow_any_instance_of(Arel::Middleware::CacheAccessor)
       .to receive(:cache_key_for_sql).with(sql).and_return('sql_cache_key')
 
-    cache = spy('cache', get: nil, set: nil)
+    cache = spy('cache', read: nil, write: nil)
 
     Arel.middleware.apply([middleware_one], cache: cache) do
       Post.first
 
-      expect(cache).to have_received(:get).with('hash_of_middleware_one|sql_cache_key')
-      expect(cache).to have_received(:set).with('hash_of_middleware_one|sql_cache_key', sql)
+      expect(cache).to have_received(:read).with('hash_of_middleware_one|sql_cache_key')
+      expect(cache).to have_received(:write).with('hash_of_middleware_one|sql_cache_key', sql)
     end
 
     Arel.middleware.apply([middleware_one, middleware_two], cache: cache) do
       Post.first
 
-      expect(cache).to have_received(:get).with('hash_of_middleware_one&hash_of_middleware_two|sql_cache_key')
-      expect(cache).to have_received(:set).with('hash_of_middleware_one&hash_of_middleware_two|sql_cache_key', sql)
+      expect(cache).to have_received(:read).with('hash_of_middleware_one&hash_of_middleware_two|sql_cache_key')
+      expect(cache).to have_received(:write).with('hash_of_middleware_one&hash_of_middleware_two|sql_cache_key', sql)
     end
   end
 end

--- a/spec/arel/transformer/caching_spec.rb
+++ b/spec/arel/transformer/caching_spec.rb
@@ -1,19 +1,30 @@
 describe 'Middleware Query Caching' do
   let(:next_middleware) { ->(new_arel) { new_arel } }
 
+  class MiddlewareOne
+    def call(arel, next_middleware)
+      next_middleware.call arel
+    end
+  end
+
+  class MiddlewareTwo
+    def call(arel, next_middleware)
+      next_middleware.call arel
+    end
+  end
+
   it 'stores the result of the middleware transformation' do
     Post.first # Warm up cache
 
-    transformer = Class.new do
-      def call(arel, next_middleware)
-        next_middleware.call arel
-      end
-    end.new
+    middleware_one = MiddlewareOne.new
+    middleware_two = MiddlewareTwo.new
 
     cache = spy('cache', get: nil, set: nil)
 
-    Arel.middleware.apply([], cache: cache) do
-      Arel.middleware.apply([transformer]) { Post.first }
+    Arel.middleware.apply([middleware_one], cache: cache) do
+      Arel.middleware.apply([middleware_two]) do
+        Post.first
+      end
     end
 
     expect(cache).to \

--- a/spec/arel/transformer/caching_spec.rb
+++ b/spec/arel/transformer/caching_spec.rb
@@ -1,16 +1,14 @@
 describe 'Middleware Query Caching' do
-  class DummyTransformer
-    def call(arel, next_middleware)
-      next_middleware.call arel
-    end
-  end
-
   let(:next_middleware) { ->(new_arel) { new_arel } }
 
   it 'stores the result of the middleware transformation' do
-    Post.first # Cache warm up
+    Post.first # Warm up cache
 
-    transformer = DummyTransformer.new
+    transformer = Class.new do
+      def call(arel, next_middleware)
+        next_middleware.call arel
+      end
+    end.new
 
     cache = spy('cache', get: nil, set: nil)
 
@@ -19,6 +17,6 @@ describe 'Middleware Query Caching' do
     expect(cache).to \
       have_received(:get).with('SELECT  "posts".* FROM "posts" ORDER BY "posts"."id" ASC LIMIT $1')
 
-    expect(cache).to have_received(:set)
+    expect(cache).to have_received(:set) # .with(......)
   end
 end

--- a/spec/arel/transformer/caching_spec.rb
+++ b/spec/arel/transformer/caching_spec.rb
@@ -5,31 +5,48 @@ describe 'Middleware Query Caching' do
     def call(arel, next_middleware)
       next_middleware.call arel
     end
+
+    def hash
+      'hash_of_middleware_one'
+    end
   end
+
 
   class MiddlewareTwo
     def call(arel, next_middleware)
       next_middleware.call arel
+    end
+
+    def hash
+      'hash_of_middleware_two'
     end
   end
 
   it 'stores the result of the middleware transformation' do
     Post.first # Warm up cache
 
+    sql = 'SELECT  "posts".* FROM "posts" ORDER BY "posts"."id" ASC LIMIT $1'
+
     middleware_one = MiddlewareOne.new
     middleware_two = MiddlewareTwo.new
+
+    allow_any_instance_of(Arel::Middleware::CacheAccessor)
+      .to receive(:cache_key_for_sql).with(sql).and_return('sql_cache_key')
 
     cache = spy('cache', get: nil, set: nil)
 
     Arel.middleware.apply([middleware_one], cache: cache) do
-      Arel.middleware.apply([middleware_two]) do
-        Post.first
-      end
+      Post.first
+
+      expect(cache).to have_received(:get).with('hash_of_middleware_one|sql_cache_key')
+      expect(cache).to have_received(:set).with('hash_of_middleware_one|sql_cache_key', sql)
     end
 
-    expect(cache).to \
-      have_received(:get).with('SELECT  "posts".* FROM "posts" ORDER BY "posts"."id" ASC LIMIT $1')
+    Arel.middleware.apply([middleware_one, middleware_two], cache: cache) do
+      Post.first
 
-    expect(cache).to have_received(:set)
+      expect(cache).to have_received(:get).with('hash_of_middleware_one&hash_of_middleware_two|sql_cache_key')
+      expect(cache).to have_received(:set).with('hash_of_middleware_one&hash_of_middleware_two|sql_cache_key', sql)
+    end
   end
 end

--- a/spec/arel/transformer/caching_spec.rb
+++ b/spec/arel/transformer/caching_spec.rb
@@ -12,11 +12,13 @@ describe 'Middleware Query Caching' do
 
     cache = spy('cache', get: nil, set: nil)
 
-    Arel.middleware.apply([transformer], cache: cache) { Post.first }
+    Arel.middleware.apply([], cache: cache) do
+      Arel.middleware.apply([transformer]) { Post.first }
+    end
 
     expect(cache).to \
       have_received(:get).with('SELECT  "posts".* FROM "posts" ORDER BY "posts"."id" ASC LIMIT $1')
 
-    expect(cache).to have_received(:set) # .with(......)
+    expect(cache).to have_received(:set)
   end
 end

--- a/spec/arel/transformer/caching_spec.rb
+++ b/spec/arel/transformer/caching_spec.rb
@@ -1,0 +1,24 @@
+describe 'Middleware Query Caching' do
+  class DummyTransformer
+    def call(arel, next_middleware)
+      next_middleware.call arel
+    end
+  end
+
+  let(:next_middleware) { ->(new_arel) { new_arel } }
+
+  it 'stores the result of the middleware transformation' do
+    Post.first # Cache warm up
+
+    transformer = DummyTransformer.new
+
+    cache = spy('cache', get: nil, set: nil)
+
+    Arel.middleware.apply([transformer], cache: cache) { Post.first }
+
+    expect(cache).to \
+      have_received(:get).with('SELECT  "posts".* FROM "posts" ORDER BY "posts"."id" ASC LIMIT $1')
+
+    expect(cache).to have_received(:set)
+  end
+end


### PR DESCRIPTION
This PR adds a mechanism to add caching that will store middleware results. In our project, I'm using it like so:
``` 
Arel.middleware.apply([middleware_one], cache: Rails.cache) do
  User.all.load
end
```