### PR TITLE
Add ability to mutate nodes with precomputed Arel::Nodes::Enhance

### DIFF
--- a/benchmark.rb
+++ b/benchmark.rb
@@ -28,7 +28,7 @@ def do_it
   enhanced_arel = Arel.enhance(arel)
 
   enhanced_arel.query(class: Arel::Attributes::Attribute).each do |node|
-    node.replace node.object
+    node.replace node
   end
 
   enhanced_arel


### PR DESCRIPTION
This allows a mutative operation on an `Arel::Nodes::Enhance` to accept a precomputed enhance node instead of a regular Arel node. 

This saves time when applying the same modification over and over again, by being able to compute the new enhanced child once. 