### PR TITLE
Set right branch and commit for code climate

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,6 @@ on:
     types: 
       - completed
 
-# permissions:
-#   # down scope as necessary via https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token
-
 jobs:
   upload_coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
     - env:
         GITHUB: ${{ toJson(github) }}
       run: |
         env
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.workflow_run.head_sha }}
     - name: Download coverage
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: test.yml
-        commit: ${{github.event.workflow_run.head_sha}}
+        commit: ${{ github.event.workflow_run.head_sha }}
         run_id: ${{ github.event.workflow_run.id }}
         run_number: ${{ github.event.workflow_run.run_number }}
         name: rspec-coverage
@@ -35,6 +35,8 @@ jobs:
       env:
         JOB_STATUS: ${{ job.status == 'Success' }}
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        GIT_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        GIT_COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
       run: |
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         chmod +x ./cc-test-reporter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
           POSTGRES_DB: arel_toolkit_test
           POSTGRES_USER: postgres
     steps:
+    - uses: actions/checkout@v2
     # From https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
     - env:
         GITHUB: ${{ toJson(github) }}
       run: |
         env
-    - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,8 @@ jobs:
     # Based on https://github.com/paambaati/codeclimate-action/blob/0f8af43fca84b500025ca48b581bcff933244252/src/main.ts#L39-L57
     - name: Set env for push event
       run: |
-        echo "GIT_BRANCH=${{ github.ref }}" >> $GITHUB_ENV
+        GIT_BRANCH=$(echo "${{ github.ref }}" | sed 's/refs\/heads\///g')
+        echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
         echo "GIT_COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
       if: ${{ github.event_name == 'push' }}
     - name: Set env for pull_request event

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 on:
   push:
-    branches: 
-      - master
   pull_request:
 
 jobs:
@@ -38,6 +36,9 @@ jobs:
         bundle exec rake clean
         bundle exec rake compile
     - name: Start coverage
+      # env:
+      #   GIT_BRANCH: ${{ github.head.ref }}
+      #   GIT_COMMIT_SHA: ${{ github.head.sha }}
       run: |
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         chmod +x ./cc-test-reporter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 on:
   push:
+    branches: 
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,17 @@ jobs:
           POSTGRES_USER: postgres
     steps:
     - uses: actions/checkout@v2
+
+    # Based on https://github.com/paambaati/codeclimate-action/blob/0f8af43fca84b500025ca48b581bcff933244252/src/main.ts#L39-L57
+    - run: |
+        echo "GIT_BRANCH=${{ github.ref }}" >> $GITHUB_ENV
+        echo "GIT_COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
+      if: ${{ github.event_name == 'push' }}
+    - run: |
+        echo "GIT_BRANCH=${{ github.head.ref }}" >> $GITHUB_ENV
+        echo "GIT_COMMIT_SHA=${{ github.head.sha }}" >> $GITHUB_ENV
+      if: ${{ github.event_name == 'pull_request' }}
+
     # From https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
     - env:
         GITHUB: ${{ toJson(github) }}
@@ -36,9 +47,6 @@ jobs:
         bundle exec rake clean
         bundle exec rake compile
     - name: Start coverage
-      # env:
-      #   GIT_BRANCH: ${{ github.head.ref }}
-      #   GIT_COMMIT_SHA: ${{ github.head.sha }}
       run: |
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         chmod +x ./cc-test-reporter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,15 @@ jobs:
     - uses: actions/checkout@v2
 
     # Based on https://github.com/paambaati/codeclimate-action/blob/0f8af43fca84b500025ca48b581bcff933244252/src/main.ts#L39-L57
-    - run: |
+    - name: Set env for push event
+      run: |
         echo "GIT_BRANCH=${{ github.ref }}" >> $GITHUB_ENV
         echo "GIT_COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
       if: ${{ github.event_name == 'push' }}
-    - run: |
-        echo "GIT_BRANCH=${{ github.head.ref }}" >> $GITHUB_ENV
-        echo "GIT_COMMIT_SHA=${{ github.head.sha }}" >> $GITHUB_ENV
+    - name: Set env for pull_request event
+      run: |
+        echo "GIT_BRANCH=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
+        echo "GIT_COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
       if: ${{ github.event_name == 'pull_request' }}
 
     # From https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts


### PR DESCRIPTION
fixes https://github.com/mvgijssel/arel_toolkit/issues/181

Follow-up from https://github.com/mvgijssel/arel_toolkit/pull/179 which forgot to set the right branch / commit for code climate. This results in no coverage being shown in the codeclimate dashboard https://codeclimate.com/github/mvgijssel/arel_toolkit

![image](https://user-images.githubusercontent.com/6029816/124900953-db036300-dfe1-11eb-864a-1b00b39077c4.png)

- Moved the checkout up so all necessary environment variables are set
- Set the right branch/sha in the coverage workflow
- Made sure that `GIT_BRANCH` and `GIT_COMMIT_SHA` are set for both a `push` and a `pull_request` event in the test workflow (Based on https://github.com/paambaati/codeclimate-action/blob/0f8af43fca84b500025ca48b581bcff933244252/src/main.ts#L39-L57)

---

After merging with master the code coverage is back! 🎉 

![image](https://user-images.githubusercontent.com/6029816/124909277-8dd7bf00-dfea-11eb-8e1f-c7a250813d7e.png)
