### PR TITLE
Comparing a type case node against any other type of node

### DIFF
--- a/lib/arel/extensions/type_cast.rb
+++ b/lib/arel/extensions/type_cast.rb
@@ -14,7 +14,7 @@ module Arel
       end
 
       def ==(other)
-        arg == other.arg && type_name == other.type_name
+        self.class == other.class && arg == other.arg && type_name == other.type_name
       end
     end
   end


### PR DESCRIPTION

This fix addresses this issue:
```
"undefined method `arg' for #<Arel::Nodes::Any:0x0000ffff8110eab0>"
```

When doing an operation like:
```
node.object.left == node.object.right
```
Where the `node.object.left` is a type cast and `node.object.right` is object other than a typecast node