### PR TITLE
feat: Support additional arguments, required for ActiveRecord 7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.7.0](https://github.com/mvgijssel/arel_toolkit/tree/v0.7.0) (2023-06-05)
+
+[Full Changelog](https://github.com/mvgijssel/arel_toolkit/compare/v0.6.0...v0.7.0)
+
+**Implemented enhancements:**
+
+- ActiveRecord 7.1 support
+
 ## [v0.6.0](https://github.com/mvgijssel/arel_toolkit/tree/v0.6.0) (2023-04-17)
 
 [Full Changelog](https://github.com/mvgijssel/arel_toolkit/compare/v0.5.0...v0.6.0)

--- a/arel_toolkit.gemspec
+++ b/arel_toolkit.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.extensions    = ['ext/pg_result_init/extconf.rb']
 
-  spec.add_dependency 'activerecord', '>= 7.0', '< 8'
+  spec.add_dependency 'activerecord', '>= 7.1', '< 8'
   spec.add_dependency 'pg', '>= 1.1.4'
   spec.add_dependency 'pg_query', '~> 2.2'
 

--- a/lib/arel/middleware/postgresql_adapter.rb
+++ b/lib/arel/middleware/postgresql_adapter.rb
@@ -38,20 +38,20 @@ module Arel
         end
       end
 
-      def exec_no_cache(sql, name, binds, async: false)
+      def exec_no_cache(sql, name, binds, async: false, **additional_arguments)
         Arel::Middleware.current_chain.execute(sql, binds) do |processed_sql, processed_binds|
           Arel::Middleware::Result.create(
-            data: super(processed_sql, name, processed_binds, async: async),
+            data: super(processed_sql, name, processed_binds, async: async, **additional_arguments),
             from: Arel::Middleware::PGResult,
             to: Arel::Middleware::PGResult,
           )
         end
       end
 
-      def exec_cache(sql, name, binds, async: false)
+      def exec_cache(sql, name, binds, async: false, **additional_arguments)
         Arel::Middleware.current_chain.execute(sql, binds) do |processed_sql, processed_binds|
           Arel::Middleware::Result.create(
-            data: super(processed_sql, name, processed_binds, async: async),
+            data: super(processed_sql, name, processed_binds, async: async, **additional_arguments),
             from: Arel::Middleware::PGResult,
             to: Arel::Middleware::PGResult,
           )

--- a/lib/arel_toolkit/version.rb
+++ b/lib/arel_toolkit/version.rb
@@ -1,3 +1,3 @@
 module ArelToolkit
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0'.freeze
 end


### PR DESCRIPTION
When using `arel_toolkit` v0.6.0 I'm running into the following error when used in a Rails 7.1 application (which is using active_record 7.1.3.3):

```
ArgumentError: unknown keywords: :allow_retry, :materialize_transactions (ArgumentError)
/app/lib/app_name/protected_attribute/connection_helpers.rb:114:in `configure_connection'
```

In `active_record` 7.1 the [exec_no_cache](https://github.com/rails/rails/blob/747a03ba7722b6f0a7ce42e86cea83cf07a2e6ef/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L884) and [exec_cache](https://github.com/rails/rails/blob/747a03ba7722b6f0a7ce42e86cea83cf07a2e6ef/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L901) methods require the keywords `:allow_retry` and `:materialize_transactions`. `arel_toolkit` was not passing these arguments.

This PR passes any additional arguments passed in to the `super` call to resolve this issue.

